### PR TITLE
Adjust the way paths and literals are counted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ maintenance = { status = "as-is" }
 
 
 [dependencies]
-syn = {version = "0.12", features = ["parsing", "printing", "clone-impls", "full", "extra-traits", "visit"]}
+syn = {version = "0.14", features = ["parsing", "printing", "clone-impls", "full", "extra-traits", "visit"]}
 clap = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,39 +53,39 @@ pub struct UnsafeCounter {
 }
 
 impl<'ast> visit::Visit<'ast> for UnsafeCounter {
-    fn visit_item_fn(&mut self, i: &'ast syn::ItemFn) {
+    fn visit_item_fn(&mut self, i: &syn::ItemFn) {
         // fn definitions
         self.functions.count(i.unsafety.is_some());
         visit::visit_item_fn(self, i);
     }
 
-    fn visit_expr(&mut self, i: &'ast syn::Expr) {
+    fn visit_expr(&mut self, i: &syn::Expr) {
         // Total number of expressions of any type
         self.exprs.count(self.in_unsafe_block);
         visit::visit_expr(self, i);
     }
 
-    fn visit_expr_unsafe(&mut self, i: &'ast syn::ExprUnsafe) {
+    fn visit_expr_unsafe(&mut self, i: &syn::ExprUnsafe) {
         // unsafe {} expression blocks
         self.in_unsafe_block = true;
         visit::visit_expr_unsafe(self, i);
         self.in_unsafe_block = false;
     }
 
-    fn visit_item_impl(&mut self, i: &'ast syn::ItemImpl) {
+    fn visit_item_impl(&mut self, i: &syn::ItemImpl) {
         // unsafe trait impl's
         self.itemimpls.count(i.unsafety.is_some());
         visit::visit_item_impl(self, i);
     }
 
-    fn visit_item_trait(&mut self, i: &'ast syn::ItemTrait) {
+    fn visit_item_trait(&mut self, i: &syn::ItemTrait) {
         // Unsafe traits
         self.itemtraits.count(i.unsafety.is_some());
         visit::visit_item_trait(self, i);
 
     }
 
-    fn visit_impl_item_method(&mut self, i: &'ast syn::ImplItemMethod) {
+    fn visit_impl_item_method(&mut self, i: &syn::ImplItemMethod) {
         self.methods.count(i.sig.unsafety.is_some());
         visit::visit_impl_item_method(self, i);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::Read;
 
 use clap::{Arg, App};
-use syn::{visit, ItemFn, Expr, ExprUnsafe, ItemImpl, ItemTrait, ImplItemMethod};
+use syn::{visit, ItemFn, Expr, ItemImpl, ItemTrait, ImplItemMethod};
 
 unsafe fn foo() {
     unsafe {
@@ -61,15 +61,21 @@ impl<'ast> visit::Visit<'ast> for UnsafeCounter {
 
     fn visit_expr(&mut self, i: &Expr) {
         // Total number of expressions of any type
-        self.exprs.count(self.in_unsafe_block);
-        visit::visit_expr(self, i);
-    }
-
-    fn visit_expr_unsafe(&mut self, i: &ExprUnsafe) {
-        // unsafe {} expression blocks
-        self.in_unsafe_block = true;
-        visit::visit_expr_unsafe(self, i);
-        self.in_unsafe_block = false;
+        match i {
+            Expr::Unsafe(i) => {
+                self.in_unsafe_block = true;
+                visit::visit_expr_unsafe(self, i);
+                self.in_unsafe_block = false;
+            }
+            Expr::Path(_) | Expr::Lit(_) => {
+                // Do not count. The expression `f(x)` should count as one
+                // expression, not three.
+            }
+            other => {
+                self.exprs.count(self.in_unsafe_block);
+                visit::visit_expr(self, other);
+            }
+        }
     }
 
     fn visit_item_impl(&mut self, i: &ItemImpl) {


### PR DESCRIPTION
An expression like `str::from_utf8_unchecked(bytes)` should be counted as one unsafe expression. That is, just `str::from_utf8_unchecked` and `bytes` by themselves are not expressions that can meaningfully be considered unsafe. A way to see this is that there would never be a reason to write a function call as:

```rust
unsafe { f }(unsafe { x })
```